### PR TITLE
fix: Parse error with type of age value #27

### DIFF
--- a/src/components/basic/view.js
+++ b/src/components/basic/view.js
@@ -12,7 +12,7 @@ export default class BasicView extends View {
     };
 
     const handleAgeChange = (e) => {
-      this.context.patient.setAge(e.target.value);
+      this.context.patient.setAge(e.target.valueAsNumber);
     };
 
     const binds = {


### PR DESCRIPTION
Changed for valueAsNumber in listener to exclude string.
https://github.com/infermedica/js-symptom-checker-example/issues/27